### PR TITLE
Allow to retrieve all data from the document.get and report.get requests

### DIFF
--- a/Ithenticate.php
+++ b/Ithenticate.php
@@ -131,11 +131,11 @@ class Ithenticate
 
         $response = $client->send(new Request('login', array(new Value($args, "struct"))));
         $response = json_decode(json_encode($response), true);
-	    
+
         if ($response['val']['me']['struct']['status']['me']['int'] === 401) {
 		throw new \Exception($response['val']['me']['struct']['messages']['me']['array'][0]['me']['string'], 401);
 	}
-	    
+
         if (isset($response['val']['me']['struct']['sid']['me']['string'])) {
             $sid = $response['val']['me']['struct']['sid']['me']['string'];
             if ($sid != null) {
@@ -225,8 +225,8 @@ class Ithenticate
         }
         return false;
     }
-	
-	
+
+
     /*
      * This method fetch all subfolders in a specific folder
     */
@@ -256,7 +256,7 @@ class Ithenticate
             return false;
         }
 
-    }	
+    }
 
     public function fetchGroupList()
     {
@@ -302,6 +302,114 @@ class Ithenticate
         } else {
             return false;
         }
+    }
+
+    /**
+     * Launches the report.get request.
+     *
+     * @param int $document_id
+     *   The document ID.
+     *
+     * @return array
+     *   An array containing the following keys: sid, api_status,
+     *   response_timestamp, id, pager, documents, folder
+     */
+    public function documentGetRequest(int $document_id)
+    {
+        $client = new Client($this->getUrl());
+        $args = array(
+            'sid' => new Value($this->getSid()),
+            'id' => new Value($document_id),
+        );
+
+        $response = $client->send(new Request('document.get', array(new Value($args, "struct"))));
+        $response = json_decode(json_encode($response), true);
+
+        $return = [];
+        if (isset($response['val']['me']['struct']['documents']['me']['array'])) {
+            foreach ($response['val']['me']['struct']['documents']['me']['array'] as $index => $document_array) {
+              $document_data = $document_array['me']['struct'];
+              if (isset($document_data['author_first']['me']['string'])) {
+                $return['documents'][$index]['author_first'] = $document_data['author_first']['me']['string'];
+              }
+              if (isset($document_data['author_last']['me']['string'])) {
+                $return['documents'][$index]['author_last'] = $document_data['author_last']['me']['string'];
+              }
+              $return['documents'][$index]['is_pending'] = $document_data['is_pending']['me']['int'];
+              $return['documents'][$index]['id'] = $document_data['id']['me']['int'];
+              $return['documents'][$index]['processed_time'] = $document_data['processed_time']['me']['dateTime.iso8601'];
+              $return['documents'][$index]['percent_match'] = $document_data['percent_match']['me']['int'];
+              $return['documents'][$index]['title'] = $document_data['title']['me']['string'];
+              $return['documents'][$index]['uploaded_time'] = $document_data['uploaded_time']['me']['dateTime.iso8601'];
+
+              if (isset($document_data['parts']['me']['array'])) {
+                foreach ($document_data['parts']['me']['array'] as $part_index => $parts_array) {
+                  $part_data = $parts_array['me']['struct'];
+                  $return['documents'][$index]['parts'][$part_index]['max_percent_match'] = $part_data['max_percent_match']['me']['int'];
+                  $return['documents'][$index]['parts'][$part_index]['processed_time'] = $part_data['processed_time']['me']['string'];
+                  $return['documents'][$index]['parts'][$part_index]['score'] = $part_data['score']['me']['int'];
+                  $return['documents'][$index]['parts'][$part_index]['words'] = $part_data['words']['me']['int'];
+                  $return['documents'][$index]['parts'][$part_index]['id'] = $part_data['id']['me']['int'];
+                  $return['documents'][$index]['parts'][$part_index]['doc_id'] = $part_data['doc_id']['me']['int'];
+                }
+              }
+            }
+            $return['sid'] = $response['val']['me']['struct']['sid']['me']['string'];
+            $return['api_status'] = $response['val']['me']['struct']['api_status']['me']['int'];
+            $return['response_timestamp'] = $response['val']['me']['struct']['response_timestamp']['me']['dateTime.iso8601'];
+            $return['folder'] = $this->readFolder($response);
+        } else {
+            $return['errors'] = $this->readErrors($response);
+        }
+
+        return $return;
+    }
+
+    /**
+     * Launches the report.get request.
+     *
+     * @param int $report_id
+     *   The document report ID.
+     * @param int $exclude_biblio
+     *   (optional) Whether to exclude biblio references. Defaults to 1.
+     * @param int $exclude_quotes
+     *   (optional) Whether to exclude quoted text. Defaults to 1.
+     * @param int $exclude_small_matches
+     *   (optional) Whether to exclude small matches. Defaults to 1.
+     *
+     * @return array
+     *   An array containing the following keys: sid, api_status,
+     *   response_timestamp, report_url, view_only_url, view_only_expires.
+     */
+    public function reportGetRequest(int $report_id, $exclude_biblio = 1, $exclude_quotes = 1, $exclude_small_matches = 1)
+    {
+        $client = new Client($this->getUrl());
+        $args = array(
+            'sid' => new Value($this->getSid()),
+            'id' => new Value($report_id),
+            'exclude_biblio' => new Value($exclude_biblio),
+            'exclude_quotes' => new Value($exclude_quotes),
+            'exclude_small_matches' => new Value($exclude_small_matches),
+        );
+
+        $response = $client->send(new Request('report.get', array(new Value($args, "struct"))));
+        $response = json_decode(json_encode($response), true);
+
+        $return = [];
+        if (isset($response['val']['me']['struct']['view_only_url']['me']['string'])) {
+            $return['sid'] = $response['val']['me']['struct']['sid']['me']['string'];
+            $return['api_status'] = $response['val']['me']['struct']['api_status']['me']['int'];
+            $return['response_timestamp'] = $response['val']['me']['struct']['response_timestamp']['me']['dateTime.iso8601'];
+
+            // The request is successful and all data exist.
+            $return['view_only_url'] = $response['val']['me']['struct']['view_only_url']['me']['string'];
+            $return['view_only_expires'] = $response['val']['me']['struct']['view_only_expires']['me']['dateTime.iso8601'];
+            $return['report_url'] = $response['val']['me']['struct']['report_url']['me']['string'];
+        } else {
+            $return['errors'] = $this->readErrors($response);
+        }
+
+        return $return;
     }
 
     public function fetchDocumentReportState($document_id)
@@ -373,5 +481,75 @@ class Ithenticate
         } else {
             return false;
         }
+    }
+
+    /**
+     * Converts the errors in the repsponse into an easy to handle array.
+     *
+     * @param array $response_array
+     *   The response after it has been envoded and decoded into an array.
+     *
+     * @return array
+     *   A multidimensioonal array where the first level is the property related
+     *   to the error and the value is an array of error messages.
+     */
+    protected function readErrors($response_array) {
+        if (!isset($response_array['val']['me']['struct']['errors']['me']['struct'])) {
+            return [];
+        }
+
+        $return = [];
+        foreach ($response_array['val']['me']['struct']['errors']['me']['struct'] as $element_name => $error_array) {
+            if (!isset($error_array['me']['array'])) {
+                // Avoid breaking the application for possible future changes.
+                continue;
+            }
+            foreach ($error_array['me']['array'] as $index => $error_data) {
+                if (!isset($error_data['me']['string'])) {
+                    // Avoid breaking the application if there is an error of a
+                    // different format.
+                    continue;
+                }
+                $return[$element_name][$index] = $error_data['me']['string'];
+            }
+        }
+        return $return;
+    }
+
+    /**
+     * Converts the folders entry in the repsponse into an easy to handle array.
+     *
+     * @param array $response_array
+     *   The response after it has been envoded and decoded into an array.
+     *
+     * @return array
+     *   A multidimensioonal array that contains information related to a
+     *   folder.
+     */
+    protected function readFolder($response_array) {
+        if (!isset($response_array['val']['me']['struct']['folder']['me']['struct'])) {
+          return [];
+        }
+
+        $return = [];
+        $folder_array = $response_array['val']['me']['struct']['folder']['me']['struct'];
+        $return['minimum_match_word_count'] = $folder_array['minimum_match_word_count']['me']['int'];
+        $return['exclude_word_count'] = $folder_array['exclude_word_count']['me']['int'];
+        $return['exclude_percent'] = $folder_array['exclude_percent']['me']['int'];
+        $return['exclude_abstracts'] = $folder_array['exclude_abstracts']['me']['int'];
+        $return['exclude_by_percent'] = $folder_array['exclude_by_percent']['me']['int'];
+        $return['id'] = $folder_array['id']['me']['int'];
+        $return['group'] = $folder_array['group']['me']['struct']['id']['me']['int'];
+        $return['exclude_biblio'] = $folder_array['exclude_biblio']['me']['int'];
+        // Ignore the 'collection_detail' as it is a complex array by itself.
+        // Ignore the 'collections' as it is a complex array by itself.
+        $return['exclude_quotes'] = $folder_array['exclude_quotes']['me']['int'];
+        $return['limit_match_size'] = $folder_array['limit_match_size']['me']['int'];
+        $return['exclude_methods'] = $folder_array['exclude_methods']['me']['int'];
+        $return['name'] = $folder_array['name']['me']['string'];
+        $return['setup_time'] = $folder_array['setup_time']['me']['dateTime.iso8601'];
+        $return['exclude_small_matches'] = $folder_array['exclude_small_matches']['me']['int'];
+
+        return $return;
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ After all simply call each method you want to use with passing the required para
 
 I strongly suggest to read the [iThenticate API Guide](http://www.ithenticate.com/hs-fs/hub/92785/file-1383985272-pdf/iTh_documentation/iThenticate_API_Manual.pdf?t=1488585417195) before using the library and its methods.
 
-### Example
+### Methods
+
+#### Submit document
 Here is one simple example to send new document:
 ```php
 $ithenticate = new \bsobbe\ithenticate\Ithenticate("username", "password");
@@ -42,6 +44,33 @@ $result = $ithenticate->submitDocument(
                 $content, //Document content fetched with php file_get_contents() function from the document file.
                 649216 //Folder number to store document (You can get folder number from last part of ithenticate panel URL).
           );
+```
+
+#### Get document data
+```php
+$ithenticate = new \bsobbe\ithenticate\Ithenticate("username", "password");
+$result = $ithenticate->documentGetRequest(12345);
+// Since we are requesting 1 document, there should be 1 document only in the response.
+$document = reset($result['documents']);
+$is_pending = $document['is_pending']; // If the report is pending.
+$document_id = $document['id'];
+$processed_time = $document['processed_time']; // The time the report has been created.
+$percent_match = $document['percent_match']; // The percentage match for the document.
+$title = $document['title']; // The submitted title of the document.
+$uploaded_time = $document['uploaded_time']; // The time the document was uploaded.
+
+// Also, $document['folder'] is available containing information related to the folder that the document is submitted
+// into.
+```
+
+#### Get report data
+```php
+$ithenticate = new \bsobbe\ithenticate\Ithenticate("username", "password");
+$result = $ithenticate->reportGetRequest(98765, 1, 1, 1); // The report ID.
+
+$view_only_url = $result['view_only_url'];
+$view_only_expires = $result['view_only_expires'];
+$report_url = $result['report_url'];
 ```
 
 ### Contribute


### PR DESCRIPTION
Currently, the library is quite useful, but in case of an error, we are not able to retrieve anything else other than a false.
Furthermore, there has to be 1 request for each value we need to get. I am creating two new requests that directly correspond to the `document.get` and the `report.get` requests and retrieve almost all data out of them. The underlying application should be responsible for handling which data to consume.